### PR TITLE
fix: Use $CLAUDE_PLUGIN_ROOT for hook commands

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node dist/hooks/post-tool-use.js"
+            "command": "node $CLAUDE_PLUGIN_ROOT/dist/hooks/post-tool-use.js"
           }
         ]
       }
@@ -17,7 +17,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node dist/hooks/stop.js"
+            "command": "node $CLAUDE_PLUGIN_ROOT/dist/hooks/stop.js"
           }
         ]
       }


### PR DESCRIPTION
## Summary
- Hook commands now use `$CLAUDE_PLUGIN_ROOT` instead of relative paths
- Fixes MODULE_NOT_FOUND errors when hooks run from project directories

## Problem
Hook commands in `hooks/hooks.json` were using relative paths:
```json
"command": "node dist/hooks/stop.js"
```

This caused errors because hooks execute from the user's project directory (cwd), not the plugin directory:
```
Error: Cannot find module '/path/to/user/project/dist/hooks/stop.js'
```

## Solution
Use `$CLAUDE_PLUGIN_ROOT` environment variable:
```json
"command": "node $CLAUDE_PLUGIN_ROOT/dist/hooks/stop.js"
```

## Test plan
- [x] All existing tests pass (699 passed)
- [ ] Manual test: verify hooks execute correctly from any project directory

🤖 Generated with [Claude Code](https://claude.ai/code)